### PR TITLE
Update to .NET 6

### DIFF
--- a/DigglesModManager.csproj
+++ b/DigglesModManager.csproj
@@ -1,18 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{30B244A1-0A22-404B-BD25-F1EAD854E3F5}</ProjectGuid>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>DigglesModManager</RootNamespace>
-    <AssemblyName>DigglesModManager</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
     <IsWebBootstrapper>false</IsWebBootstrapper>
-    <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -27,137 +17,29 @@
     <ApplicationVersion>1.3.1.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWindowsForms>true</UseWindowsForms>
+    <UseWPF>true</UseWPF>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+	<Deterministic>false</Deterministic>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>wiggles.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Deployment" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Log.cs" />
-    <Compile Include="FormMain.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="FormMain.Designer.cs">
-      <DependentUpon>FormMain.cs</DependentUpon>
-    </Compile>
-    <Compile Include="FormModSettings.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="FormModSettings.Designer.cs">
-      <DependentUpon>FormModSettings.cs</DependentUpon>
-    </Compile>
-    <Compile Include="Helpers.cs" />
-    <Compile Include="Mod.cs" />
-    <Compile Include="Model\AppSettings.cs" />
-    <Compile Include="Model\ModConfig.cs" />
-    <Compile Include="Model\ModDirectory.cs" />
-    <Compile Include="Model\ModDirectoryType.cs" />
-    <Compile Include="Model\ModDirectoryCondition.cs" />
-    <Compile Include="Model\ModDirectoryConditionType.cs" />
-    <Compile Include="Model\ModMessage.cs" />
-    <Compile Include="Model\ModLinks.cs" />
-    <Compile Include="Model\ModTranslationString.cs" />
-    <Compile Include="Model\ModSettingsVariable.cs" />
-    <Compile Include="Model\ModMessageType.cs" />
-    <Compile Include="Model\ModVariableType.cs" />
-    <Compile Include="Model\ModVariableValue.cs" />
-    <Compile Include="Paths.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="ProgressBarManipulator.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Service\ModdingService.cs" />
-    <Compile Include="ToolTipListBox.cs">
+    <Compile Update="ToolTipListBox.cs">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="ToolTipListBox.Designer.cs">
-      <DependentUpon>ToolTipListBox.cs</DependentUpon>
-    </Compile>
-    <EmbeddedResource Include="FormMain.resx">
-      <DependentUpon>FormMain.cs</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Include="FormModSettings.resx">
-      <DependentUpon>FormModSettings.cs</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Resources.resx</DependentUpon>
-      <DesignTime>True</DesignTime>
-    </Compile>
-    <EmbeddedResource Include="ToolTipListBox.resx">
-      <DependentUpon>ToolTipListBox.cs</DependentUpon>
-    </EmbeddedResource>
-    <None Include="LICENSE">
+    <None Update="LICENSE">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
-    <None Include="README.md">
+    <None Update="README.md">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config">
-      <SubType>Designer</SubType>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Resources\ErrorIcon.png" />
     <Content Include="Resources\Icons\reload.png" />
     <Content Include="Resources\Icons\settings.png" />
-    <None Include="Resources\WarningIcon.png" />
-    <None Include="Resources\InfoIcon.png" />
     <Content Include="wiggles.ico" />
   </ItemGroup>
   <ItemGroup>
@@ -172,13 +54,15 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.336902">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
 </Project>

--- a/DigglesModManager.csproj
+++ b/DigglesModManager.csproj
@@ -55,14 +55,6 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.336902">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.0" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/FormMain.Designer.cs
+++ b/FormMain.Designer.cs
@@ -521,8 +521,8 @@
             // 
             // FormMain
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(874, 348);
             this.Controls.Add(this.descriptionLabel);
             this.Controls.Add(this.descriptionBox);

--- a/FormMain.Designer.cs
+++ b/FormMain.Designer.cs
@@ -40,9 +40,9 @@
             this.mainPanel = new System.Windows.Forms.Panel();
             this.activeModsLabel = new System.Windows.Forms.Label();
             this.activeModsListView = new System.Windows.Forms.ListView();
-            this.header2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.header2 = new System.Windows.Forms.ColumnHeader();
             this.availableModsListView = new System.Windows.Forms.ListView();
-            this.header1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.header1 = new System.Windows.Forms.ColumnHeader();
             this.availableModsLabel = new System.Windows.Forms.Label();
             this.statusBar = new System.Windows.Forms.StatusStrip();
             this.statusBarLabelLeft = new System.Windows.Forms.ToolStripStatusLabel();
@@ -82,10 +82,11 @@
             // installModButton
             // 
             this.installModButton.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.installModButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.installModButton.Location = new System.Drawing.Point(256, 90);
+            this.installModButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            this.installModButton.Location = new System.Drawing.Point(299, 104);
+            this.installModButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.installModButton.Name = "installModButton";
-            this.installModButton.Size = new System.Drawing.Size(40, 32);
+            this.installModButton.Size = new System.Drawing.Size(47, 37);
             this.installModButton.TabIndex = 2;
             this.installModButton.Text = "▶";
             this.installModButton.UseVisualStyleBackColor = true;
@@ -94,10 +95,11 @@
             // uninstallModButton
             // 
             this.uninstallModButton.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.uninstallModButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.uninstallModButton.Location = new System.Drawing.Point(256, 128);
+            this.uninstallModButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            this.uninstallModButton.Location = new System.Drawing.Point(299, 148);
+            this.uninstallModButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.uninstallModButton.Name = "uninstallModButton";
-            this.uninstallModButton.Size = new System.Drawing.Size(40, 32);
+            this.uninstallModButton.Size = new System.Drawing.Size(47, 37);
             this.uninstallModButton.TabIndex = 3;
             this.uninstallModButton.Text = "◀";
             this.uninstallModButton.UseVisualStyleBackColor = true;
@@ -107,10 +109,11 @@
             // 
             this.letsModButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.letsModButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.letsModButton.Location = new System.Drawing.Point(604, 237);
+            this.letsModButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            this.letsModButton.Location = new System.Drawing.Point(705, 273);
+            this.letsModButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.letsModButton.Name = "letsModButton";
-            this.letsModButton.Size = new System.Drawing.Size(140, 40);
+            this.letsModButton.Size = new System.Drawing.Size(163, 46);
             this.letsModButton.TabIndex = 4;
             this.letsModButton.Text = "Let\'s Mod";
             this.letsModButton.UseVisualStyleBackColor = true;
@@ -119,11 +122,12 @@
             // refreshButton
             // 
             this.refreshButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.refreshButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 24F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.refreshButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 24F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
             this.refreshButton.Image = ((System.Drawing.Image)(resources.GetObject("refreshButton.Image")));
-            this.refreshButton.Location = new System.Drawing.Point(256, 210);
+            this.refreshButton.Location = new System.Drawing.Point(299, 242);
+            this.refreshButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.refreshButton.Name = "refreshButton";
-            this.refreshButton.Size = new System.Drawing.Size(40, 40);
+            this.refreshButton.Size = new System.Drawing.Size(47, 46);
             this.refreshButton.TabIndex = 7;
             this.refreshButton.TextAlign = System.Drawing.ContentAlignment.TopLeft;
             this.refreshButton.UseVisualStyleBackColor = true;
@@ -132,11 +136,12 @@
             // moveUpButton
             // 
             this.moveUpButton.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.moveUpButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.moveUpButton.Location = new System.Drawing.Point(558, 90);
+            this.moveUpButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            this.moveUpButton.Location = new System.Drawing.Point(651, 104);
+            this.moveUpButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.moveUpButton.Name = "moveUpButton";
             this.moveUpButton.Padding = new System.Windows.Forms.Padding(2, 0, 0, 2);
-            this.moveUpButton.Size = new System.Drawing.Size(40, 32);
+            this.moveUpButton.Size = new System.Drawing.Size(47, 37);
             this.moveUpButton.TabIndex = 8;
             this.moveUpButton.Text = "▲";
             this.moveUpButton.UseVisualStyleBackColor = true;
@@ -145,11 +150,12 @@
             // moveDownButton
             // 
             this.moveDownButton.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.moveDownButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.moveDownButton.Location = new System.Drawing.Point(558, 128);
+            this.moveDownButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            this.moveDownButton.Location = new System.Drawing.Point(651, 148);
+            this.moveDownButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.moveDownButton.Name = "moveDownButton";
             this.moveDownButton.Padding = new System.Windows.Forms.Padding(2, 0, 0, 2);
-            this.moveDownButton.Size = new System.Drawing.Size(40, 32);
+            this.moveDownButton.Size = new System.Drawing.Size(47, 37);
             this.moveDownButton.TabIndex = 9;
             this.moveDownButton.Text = "▼";
             this.moveDownButton.UseVisualStyleBackColor = true;
@@ -160,11 +166,12 @@
             this.modSettingsButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.modSettingsButton.BackColor = System.Drawing.SystemColors.Control;
             this.modSettingsButton.Enabled = false;
-            this.modSettingsButton.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.modSettingsButton.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
             this.modSettingsButton.Image = ((System.Drawing.Image)(resources.GetObject("modSettingsButton.Image")));
-            this.modSettingsButton.Location = new System.Drawing.Point(558, 210);
+            this.modSettingsButton.Location = new System.Drawing.Point(651, 242);
+            this.modSettingsButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.modSettingsButton.Name = "modSettingsButton";
-            this.modSettingsButton.Size = new System.Drawing.Size(40, 40);
+            this.modSettingsButton.Size = new System.Drawing.Size(47, 46);
             this.modSettingsButton.TabIndex = 11;
             this.modSettingsButton.UseVisualStyleBackColor = false;
             this.modSettingsButton.Click += new System.EventHandler(this.button_mod_settings_Click);
@@ -183,17 +190,19 @@
             this.mainPanel.Controls.Add(this.moveDownButton);
             this.mainPanel.Controls.Add(this.installModButton);
             this.mainPanel.Controls.Add(this.moveUpButton);
-            this.mainPanel.Location = new System.Drawing.Point(0, 27);
+            this.mainPanel.Location = new System.Drawing.Point(0, 31);
+            this.mainPanel.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.mainPanel.Name = "mainPanel";
-            this.mainPanel.Size = new System.Drawing.Size(598, 253);
+            this.mainPanel.Size = new System.Drawing.Size(698, 292);
             this.mainPanel.TabIndex = 12;
             // 
             // activeModsLabel
             // 
             this.activeModsLabel.AutoSize = true;
-            this.activeModsLabel.Location = new System.Drawing.Point(302, 4);
+            this.activeModsLabel.Location = new System.Drawing.Point(352, 5);
+            this.activeModsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.activeModsLabel.Name = "activeModsLabel";
-            this.activeModsLabel.Size = new System.Drawing.Size(66, 13);
+            this.activeModsLabel.Size = new System.Drawing.Size(73, 15);
             this.activeModsLabel.TabIndex = 16;
             this.activeModsLabel.Text = "Active Mods";
             // 
@@ -205,12 +214,12 @@
             this.header2});
             this.activeModsListView.FullRowSelect = true;
             this.activeModsListView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
-            this.activeModsListView.HideSelection = false;
-            this.activeModsListView.Location = new System.Drawing.Point(305, 21);
+            this.activeModsListView.Location = new System.Drawing.Point(356, 24);
+            this.activeModsListView.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.activeModsListView.MultiSelect = false;
             this.activeModsListView.Name = "activeModsListView";
             this.activeModsListView.ShowItemToolTips = true;
-            this.activeModsListView.Size = new System.Drawing.Size(247, 229);
+            this.activeModsListView.Size = new System.Drawing.Size(288, 264);
             this.activeModsListView.TabIndex = 15;
             this.activeModsListView.UseCompatibleStateImageBehavior = false;
             this.activeModsListView.View = System.Windows.Forms.View.Details;
@@ -229,13 +238,13 @@
             this.header1});
             this.availableModsListView.FullRowSelect = true;
             this.availableModsListView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
-            this.availableModsListView.HideSelection = false;
-            this.availableModsListView.Location = new System.Drawing.Point(6, 21);
+            this.availableModsListView.Location = new System.Drawing.Point(7, 24);
+            this.availableModsListView.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.availableModsListView.MultiSelect = false;
             this.availableModsListView.Name = "availableModsListView";
             this.availableModsListView.RightToLeft = System.Windows.Forms.RightToLeft.No;
             this.availableModsListView.ShowItemToolTips = true;
-            this.availableModsListView.Size = new System.Drawing.Size(244, 229);
+            this.availableModsListView.Size = new System.Drawing.Size(284, 264);
             this.availableModsListView.Sorting = System.Windows.Forms.SortOrder.Ascending;
             this.availableModsListView.TabIndex = 14;
             this.availableModsListView.UseCompatibleStateImageBehavior = false;
@@ -250,9 +259,10 @@
             // availableModsLabel
             // 
             this.availableModsLabel.AutoSize = true;
-            this.availableModsLabel.Location = new System.Drawing.Point(3, 4);
+            this.availableModsLabel.Location = new System.Drawing.Point(4, 5);
+            this.availableModsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.availableModsLabel.Name = "availableModsLabel";
-            this.availableModsLabel.Size = new System.Drawing.Size(79, 13);
+            this.availableModsLabel.Size = new System.Drawing.Size(88, 15);
             this.availableModsLabel.TabIndex = 12;
             this.availableModsLabel.Text = "Available Mods";
             // 
@@ -263,9 +273,10 @@
             this.statusBarLabelSpring1,
             this.statusBarLabelRight,
             this.modProgressStatusBar});
-            this.statusBar.Location = new System.Drawing.Point(0, 280);
+            this.statusBar.Location = new System.Drawing.Point(0, 324);
             this.statusBar.Name = "statusBar";
-            this.statusBar.Size = new System.Drawing.Size(749, 22);
+            this.statusBar.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
+            this.statusBar.Size = new System.Drawing.Size(874, 24);
             this.statusBar.SizingGrip = false;
             this.statusBar.TabIndex = 14;
             this.statusBar.Text = "Hello!";
@@ -273,26 +284,26 @@
             // statusBarLabelLeft
             // 
             this.statusBarLabelLeft.Name = "statusBarLabelLeft";
-            this.statusBarLabelLeft.Size = new System.Drawing.Size(0, 17);
+            this.statusBarLabelLeft.Size = new System.Drawing.Size(0, 19);
             // 
             // statusBarLabelSpring1
             // 
             this.statusBarLabelSpring1.Name = "statusBarLabelSpring1";
-            this.statusBarLabelSpring1.Size = new System.Drawing.Size(562, 17);
+            this.statusBarLabelSpring1.Size = new System.Drawing.Size(693, 19);
             this.statusBarLabelSpring1.Spring = true;
             // 
             // statusBarLabelRight
             // 
             this.statusBarLabelRight.Margin = new System.Windows.Forms.Padding(0, 3, 10, 2);
             this.statusBarLabelRight.Name = "statusBarLabelRight";
-            this.statusBarLabelRight.Size = new System.Drawing.Size(0, 17);
+            this.statusBarLabelRight.Size = new System.Drawing.Size(0, 19);
             // 
             // modProgressStatusBar
             // 
             this.modProgressStatusBar.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
             this.modProgressStatusBar.Margin = new System.Windows.Forms.Padding(1, 3, -8, 3);
             this.modProgressStatusBar.Name = "modProgressStatusBar";
-            this.modProgressStatusBar.Size = new System.Drawing.Size(138, 16);
+            this.modProgressStatusBar.Size = new System.Drawing.Size(161, 18);
             this.modProgressStatusBar.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
             this.modProgressStatusBar.Value = 48;
             // 
@@ -304,7 +315,8 @@
             this.helpToolStripMenuItem});
             this.mainMenuStrip.Location = new System.Drawing.Point(0, 0);
             this.mainMenuStrip.Name = "mainMenuStrip";
-            this.mainMenuStrip.Size = new System.Drawing.Size(749, 24);
+            this.mainMenuStrip.Padding = new System.Windows.Forms.Padding(7, 2, 0, 2);
+            this.mainMenuStrip.Size = new System.Drawing.Size(874, 24);
             this.mainMenuStrip.TabIndex = 15;
             this.mainMenuStrip.Text = "menuStrip1";
             // 
@@ -489,27 +501,29 @@
             this.descriptionBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.descriptionBox.Location = new System.Drawing.Point(604, 48);
+            this.descriptionBox.Location = new System.Drawing.Point(705, 55);
+            this.descriptionBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.descriptionBox.Name = "descriptionBox";
             this.descriptionBox.ReadOnly = true;
-            this.descriptionBox.Size = new System.Drawing.Size(140, 183);
+            this.descriptionBox.Size = new System.Drawing.Size(163, 211);
             this.descriptionBox.TabIndex = 16;
             this.descriptionBox.Text = "";
             // 
             // descriptionLabel
             // 
             this.descriptionLabel.AutoSize = true;
-            this.descriptionLabel.Location = new System.Drawing.Point(601, 31);
+            this.descriptionLabel.Location = new System.Drawing.Point(701, 36);
+            this.descriptionLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.descriptionLabel.Name = "descriptionLabel";
-            this.descriptionLabel.Size = new System.Drawing.Size(84, 13);
+            this.descriptionLabel.Size = new System.Drawing.Size(95, 15);
             this.descriptionLabel.TabIndex = 17;
             this.descriptionLabel.Text = "Mod Description";
             // 
             // FormMain
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(749, 302);
+            this.ClientSize = new System.Drawing.Size(874, 348);
             this.Controls.Add(this.descriptionLabel);
             this.Controls.Add(this.descriptionBox);
             this.Controls.Add(this.statusBar);
@@ -518,7 +532,8 @@
             this.Controls.Add(this.mainPanel);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.mainMenuStrip;
-            this.MinimumSize = new System.Drawing.Size(765, 341);
+            this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.MinimumSize = new System.Drawing.Size(890, 387);
             this.Name = "FormMain";
             this.Text = "DigglesModManager";
             this.Load += new System.EventHandler(this.Form1_Load);

--- a/FormMain.resx
+++ b/FormMain.resx
@@ -1,64 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<root>
-  <!-- 
-    Microsoft ResX Schema 
-    
-    Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
-    associated with the data types.
-    
-    Example:
-    
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">2.0</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        <value>[base64 mime encoded serialized .NET Framework object]</value>
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-        <comment>This is a comment</comment>
-    </data>
-                
-    There are any number of "resheader" rows that contain simple 
-    name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
-    mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
-    extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
-    read any of the formats listed below.
-    
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-            : and then encoded with base64 encoding.
-    
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-            : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
-            : using a System.ComponentModel.TypeConverter
-            : and then encoded with base64 encoding.
-    -->
+﻿<root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -121,7 +61,7 @@
   <data name="refreshButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAhCAYAAADDAmudAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        EwAACxMBAJqcGAAAAAd0SU1FB+AKGg0EIhZQCcsAAAG9SURBVEhLtZa9ShxhGEYnkmjQBBXsVYJNglcQ
+        EgAACxIB0t1+/AAAAAd0SU1FB+AKGg0EIhZQCcsAAAG9SURBVEhLtZa9ShxhGEYnkmjQBBXsVYJNglcQ
         1BRiKwiCNxAtUhiSQkgCiaRStBJtgqA3IdY2YqWd1umCgogkJpqo55nZd/PuMKP77cweOOzMs/C8zM/3
         7UaBLOCT5LB8PuENtsdnJTOHKm/KgPdo5fIxlsYs+nI5g0PYh63YMFnlWW5iJwbzBbMK81zDYLKGrOAu
         XuF1JTN/YDDpIf4t0q05Qv/9CQbjh2S9ppPohxxiDdP4KjnMxYbkrYNR9EPGscolKhzBBwpyWMKnyWEm
@@ -135,7 +75,7 @@
   <data name="modSettingsButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        xAAADsQBlSsOGwAAAAd0SU1FB+AKGg0BKxL7RSoAAAGPSURBVEhLrdW9LgVBGMbxlYgIidCpcAE+WhFB
+        wwAADsMBx2+oZAAAAAd0SU1FB+AKGg0BKxL7RSoAAAGPSURBVEhLrdW9LgVBGMbxlYgIidCpcAE+WhFB
         T++jcxqJG1BwAaISlULrCiTE5wXoJIRKJVH7KFDg/0xmYvb1nnUS+yS/nN0578xuZndnihbz5XhELemB
         dwGpJXPwBpd+tJxODKI3nP1kC97gsog8fRhCRzgz2YM6XWETkziMbZ7P+LuPaajPTWzbQSka7BX5AM/m
         vMqLOX/CKELasIu8oA7bCBmHV2C94SzSsVdjDaNYzxqaOYFe1+5Ix2rzanPzCNFD8QpEAymaypR0fAqv
@@ -157,7 +97,7 @@
   <data name="modSettingsMenuButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        xAAADsQBlSsOGwAAAAd0SU1FB+AKGg0BKxL7RSoAAAGPSURBVEhLrdW9LgVBGMbxlYgIidCpcAE+WhFB
+        wwAADsMBx2+oZAAAAAd0SU1FB+AKGg0BKxL7RSoAAAGPSURBVEhLrdW9LgVBGMbxlYgIidCpcAE+WhFB
         T++jcxqJG1BwAaISlULrCiTE5wXoJIRKJVH7KFDg/0xmYvb1nnUS+yS/nN0578xuZndnihbz5XhELemB
         dwGpJXPwBpd+tJxODKI3nP1kC97gsog8fRhCRzgz2YM6XWETkziMbZ7P+LuPaajPTWzbQSka7BX5AM/m
         vMqLOX/CKELasIu8oA7bCBmHV2C94SzSsVdjDaNYzxqaOYFe1+5Ix2rzanPzCNFD8QpEAymaypR0fAqv

--- a/FormMain.resx
+++ b/FormMain.resx
@@ -61,7 +61,7 @@
   <data name="refreshButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAhCAYAAADDAmudAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        EgAACxIB0t1+/AAAAAd0SU1FB+AKGg0EIhZQCcsAAAG9SURBVEhLtZa9ShxhGEYnkmjQBBXsVYJNglcQ
+        EQAACxEBf2RfkQAAAAd0SU1FB+AKGg0EIhZQCcsAAAG9SURBVEhLtZa9ShxhGEYnkmjQBBXsVYJNglcQ
         1BRiKwiCNxAtUhiSQkgCiaRStBJtgqA3IdY2YqWd1umCgogkJpqo55nZd/PuMKP77cweOOzMs/C8zM/3
         7UaBLOCT5LB8PuENtsdnJTOHKm/KgPdo5fIxlsYs+nI5g0PYh63YMFnlWW5iJwbzBbMK81zDYLKGrOAu
         XuF1JTN/YDDpIf4t0q05Qv/9CQbjh2S9ppPohxxiDdP4KjnMxYbkrYNR9EPGscolKhzBBwpyWMKnyWEm
@@ -75,7 +75,7 @@
   <data name="modSettingsButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAAd0SU1FB+AKGg0BKxL7RSoAAAGPSURBVEhLrdW9LgVBGMbxlYgIidCpcAE+WhFB
+        wgAADsIBFShKgAAAAAd0SU1FB+AKGg0BKxL7RSoAAAGPSURBVEhLrdW9LgVBGMbxlYgIidCpcAE+WhFB
         T++jcxqJG1BwAaISlULrCiTE5wXoJIRKJVH7KFDg/0xmYvb1nnUS+yS/nN0578xuZndnihbz5XhELemB
         dwGpJXPwBpd+tJxODKI3nP1kC97gsog8fRhCRzgz2YM6XWETkziMbZ7P+LuPaajPTWzbQSka7BX5AM/m
         vMqLOX/CKELasIu8oA7bCBmHV2C94SzSsVdjDaNYzxqaOYFe1+5Ix2rzanPzCNFD8QpEAymaypR0fAqv
@@ -97,7 +97,7 @@
   <data name="modSettingsMenuButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAAd0SU1FB+AKGg0BKxL7RSoAAAGPSURBVEhLrdW9LgVBGMbxlYgIidCpcAE+WhFB
+        wgAADsIBFShKgAAAAAd0SU1FB+AKGg0BKxL7RSoAAAGPSURBVEhLrdW9LgVBGMbxlYgIidCpcAE+WhFB
         T++jcxqJG1BwAaISlULrCiTE5wXoJIRKJVH7KFDg/0xmYvb1nnUS+yS/nN0578xuZndnihbz5XhELemB
         dwGpJXPwBpd+tJxODKI3nP1kC97gsog8fRhCRzgz2YM6XWETkziMbZ7P+LuPaajPTWzbQSka7BX5AM/m
         vMqLOX/CKELasIu8oA7bCBmHV2C94SzSsVdjDaNYzxqaOYFe1+5Ix2rzanPzCNFD8QpEAymaypR0fAqv

--- a/FormModSettings.Designer.cs
+++ b/FormModSettings.Designer.cs
@@ -92,8 +92,8 @@
             // 
             // FormModSettings
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(545, buttonY + 35);
             this.Controls.Add(this.closeButton);
             this.Controls.Add(this.setDefaultButton);

--- a/Program.cs
+++ b/Program.cs
@@ -13,6 +13,7 @@ namespace DigglesModManager
         public static void Main()
         {
             Application.EnableVisualStyles();
+            Application.SetHighDpiMode(HighDpiMode.SystemAware);
             Application.SetCompatibleTextRenderingDefault(false);
             try
             {

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace DigglesModManager.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.2.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.3.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
-</packages>


### PR DESCRIPTION
Unfortunately, the developer pack of .NET Framework 4.0 is not available any longer: https://dotnet.microsoft.com/en-us/download/dotnet-framework/net40

So, the support for Windows XP can no longer be maintained.
This PR updates the underlying .NET framework to the actual version 6: https://dotnet.microsoft.com/en-us/download/dotnet/6.0

- Update to .NET 6
- Fix #40 